### PR TITLE
Feature/fix startup bump version

### DIFF
--- a/make
+++ b/make
@@ -6,7 +6,7 @@ VERSION_EPOCH=2:
 VERSION_SUFFIX=os8
 MAINTAINER="adrian@opensignal.com"
 
-wget -c https://github.com/prometheus/node_exporter/releases/download/$VERSION/node_exporter-$VERSION.linux-amd64.tar.gz
+wget -c https://github.com/prometheus/node_exporter/releases/download/v$VERSION/node_exporter-$VERSION.linux-amd64.tar.gz
 tar xzf node_exporter-$VERSION.linux-amd64.tar.gz
 
 fpm -f -m "$MAINTAINER" -t deb -s dir -n prometheus-node_exporter -v $VERSION_EPOCH$VERSION-$VERSION_SUFFIX \

--- a/make
+++ b/make
@@ -1,7 +1,7 @@
 
 #!/bin/sh
 
-VERSION=0.12.0
+VERSION=0.14.0
 VERSION_EPOCH=2:
 VERSION_SUFFIX=os8
 MAINTAINER="adrian@opensignal.com"

--- a/postinst
+++ b/postinst
@@ -8,7 +8,7 @@ if ! [ -d "$DIR" ]; then
 fi
 
 # cope with both systemd and upstart
-if  ps -p1 | grep systemd > /dev/null; then
+if [ -x /bin/systemd ]; then
   systemctl daemon-reload
   systemctl enable prometheus-node_exporter.service
   systemctl restart prometheus-node_exporter


### PR DESCRIPTION
this is breaking docker builds of os-api (eventually we may drop this but for now this seems good)
looking at the release notes it looks like we can bump up to 0.14.0 (from 0.12.0) without any issues.
Higher than that requires changes.